### PR TITLE
[feature] 로그인 API 및 Security 작업

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,6 +22,11 @@ repositories {
 }
 
 dependencies {
+    // JWT
+    compileOnly group: 'io.jsonwebtoken', name: 'jjwt-api', version: '0.11.5'
+    runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.11.5'
+    runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-jackson', version: '0.11.5'
+
     // swagger
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'
 

--- a/src/main/java/com/teamJ/budgetManagementApplication/common/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/teamJ/budgetManagementApplication/common/security/JwtAuthenticationFilter.java
@@ -1,0 +1,80 @@
+package com.teamJ.budgetManagementApplication.common.security;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.teamJ.budgetManagementApplication.common.dto.ApiResponseDto;
+import com.teamJ.budgetManagementApplication.user.dto.LoginRequestDto;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+import java.io.IOException;
+
+@Slf4j(topic = "로그인 및 JWT 생성")
+public class JwtAuthenticationFilter extends UsernamePasswordAuthenticationFilter {
+    private final JwtUtil jwtUtil;
+
+    public JwtAuthenticationFilter(JwtUtil jwtUtil) {
+        this.jwtUtil = jwtUtil;
+        setFilterProcessesUrl("/api/users/login");
+    }
+
+    @Override
+    public Authentication attemptAuthentication(HttpServletRequest request, HttpServletResponse response) throws AuthenticationException {
+        log.info("로그인 시도");
+        try {
+            LoginRequestDto requestDto = new ObjectMapper().readValue(request.getInputStream(), LoginRequestDto.class);
+
+            return getAuthenticationManager().authenticate(
+                    new UsernamePasswordAuthenticationToken(
+                            requestDto.getAccount(),
+                            requestDto.getPassword(),
+                            null
+                    )
+            );
+        } catch (IOException e) {
+            log.error(e.getMessage());
+            throw new RuntimeException(e.getMessage());
+        }
+    }
+
+    @Override
+    protected void successfulAuthentication(HttpServletRequest request,
+                                            HttpServletResponse response,
+                                            FilterChain chain,
+                                            Authentication authResult) throws IOException {
+        log.info("로그인 성공 및 JWT 생성");
+        String account = ((UserDetailsImpl) authResult.getPrincipal()).getAccount();
+
+        String token = jwtUtil.createToken(account);
+        response.addHeader(JwtUtil.AUTHORIZATION_HEADER, token);
+
+        response.setStatus(200);
+        response.setContentType("application/json");
+        String result = new ObjectMapper().writeValueAsString(
+                new ApiResponseDto(HttpStatus.OK.value(), "login success")
+        );
+
+        response.getOutputStream().print(result);
+    }
+
+    @Override
+    protected void unsuccessfulAuthentication(HttpServletRequest request,
+                                              HttpServletResponse response,
+                                              AuthenticationException failed) throws IOException {
+        log.info("로그인 실패");
+
+        response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+        response.setContentType("application/json");
+        String result = new ObjectMapper().writeValueAsString(
+                new ApiResponseDto(HttpStatus.BAD_REQUEST.value(), "login failure")
+        );
+
+        response.getOutputStream().print(result);
+    }
+}

--- a/src/main/java/com/teamJ/budgetManagementApplication/common/security/JwtAuthorizationFilter.java
+++ b/src/main/java/com/teamJ/budgetManagementApplication/common/security/JwtAuthorizationFilter.java
@@ -1,0 +1,114 @@
+package com.teamJ.budgetManagementApplication.common.security;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.teamJ.budgetManagementApplication.common.dto.ApiResponseDto;
+import io.jsonwebtoken.Claims;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@Slf4j(topic = "JWT 검증 및 인가")
+public class JwtAuthorizationFilter extends OncePerRequestFilter {
+
+    private final JwtUtil jwtUtil;
+    private final UserDetailsServiceImpl userDetailsService;
+
+    public JwtAuthorizationFilter(JwtUtil jwtUtil, UserDetailsServiceImpl userDetailsService) {
+        this.jwtUtil = jwtUtil;
+        this.userDetailsService = userDetailsService;
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest req,
+                                    HttpServletResponse res,
+                                    FilterChain filterChain) throws ServletException, IOException {
+        // Header에서 jwt 토큰 받아오기
+        String tokenValue = jwtUtil.getTokenFromRequest(req);
+
+        if (StringUtils.hasText(tokenValue)) {
+            // 토큰 검증
+            if (notValidate(res, tokenValue)) return;
+
+            // 토큰에서 사용자 정보 가져오기
+            Claims info = getClaims(res, tokenValue);
+            if (info == null) return;
+
+            // 사용자 정보 인증 객체에 담기
+            if (userInfoInAuthentication(info)) return;
+        }
+
+        filterChain.doFilter(req, res);
+    }
+
+
+    private boolean notValidate(HttpServletResponse res, String tokenValue) throws IOException {
+        if (!jwtUtil.validateToken(tokenValue)) {
+            res.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+            res.setContentType("application/json");
+            String result = new ObjectMapper().writeValueAsString(
+                    new ApiResponseDto(HttpStatus.BAD_REQUEST.value(), "INVALID_TOKEN")
+            );
+
+            res.getOutputStream().print(result);
+            return true;
+        }
+        return false;
+    }
+
+    private Claims getClaims(HttpServletResponse res, String tokenValue) throws IOException {
+        Claims info;
+
+        try {
+            info = jwtUtil.getUserInfoFromToken(tokenValue);
+        } catch (Exception e) {
+            // JWT 검증에 실패한 경우 처리
+            res.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+            res.setContentType("application/json");
+            String result = new ObjectMapper().writeValueAsString(
+                    new ApiResponseDto(HttpStatus.BAD_REQUEST.value(), "INVALID_TOKEN")
+            );
+
+            res.getOutputStream().print(result);
+            return null;
+        }
+        return info;
+    }
+
+    private boolean userInfoInAuthentication(Claims info) {
+        try {
+            setAuthentication(info.getSubject());
+        } catch (Exception e) {
+            // 인증 처리에 실패한 경우 처리
+            log.error(e.getMessage());
+            return true;
+        }
+        return false;
+    }
+
+    // 인증 처리
+    public void setAuthentication(String account) {
+        SecurityContext context = SecurityContextHolder.createEmptyContext();
+        Authentication authentication = createAuthentication(account);
+        context.setAuthentication(authentication);
+
+        SecurityContextHolder.setContext(context);
+    }
+
+    // 인증 객체 생성
+    private Authentication createAuthentication(String account) {
+        UserDetails userDetails = userDetailsService.loadUserByUsername(account);
+        return new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
+    }
+}

--- a/src/main/java/com/teamJ/budgetManagementApplication/common/security/JwtUtil.java
+++ b/src/main/java/com/teamJ/budgetManagementApplication/common/security/JwtUtil.java
@@ -1,0 +1,79 @@
+package com.teamJ.budgetManagementApplication.common.security;
+
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.security.Keys;
+import jakarta.annotation.PostConstruct;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.extern.slf4j.Slf4j;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+import java.security.Key;
+import java.util.Base64;
+import java.util.Date;
+
+@Component
+@Slf4j(topic = "JWT 로그")
+public class JwtUtil {
+    public static final String AUTHORIZATION_HEADER = "Authorization";        // Header KEY 값
+    public static final String BEARER_PREFIX = "Bearer ";        // Token 식별자
+    private static final long TOKEN_TIME = 30 * 60 * 1000L;        // 토큰 만료시간: 30 분
+
+    @Value("${jwt.secret.key}") // Base64 Encode 한 SecretKey
+    private String secretKey;
+    private Key key;
+    private static final SignatureAlgorithm signatureAlgorithm = SignatureAlgorithm.HS256;
+
+    @PostConstruct
+    public void init() {
+        byte[] bytes = Base64.getDecoder().decode(secretKey);
+        key = Keys.hmacShaKeyFor(bytes);
+    }
+
+    // JWT 생성
+    public String createToken(String account) {
+        Date date = new Date();
+
+        return BEARER_PREFIX +
+                Jwts.builder()
+                        .setSubject(account) // 사용자 식별자값
+                        .setExpiration(new Date(date.getTime() + TOKEN_TIME)) // 만료 시간
+                        .setIssuedAt(date) // 발급일
+                        .signWith(key, signatureAlgorithm) // 암호화 알고리즘
+                        .compact();
+    }
+
+    // HttpServletRequest 에서 Header Value : JWT 가져오기
+    public String getTokenFromRequest(HttpServletRequest req) {
+        String bearerToken = req.getHeader(AUTHORIZATION_HEADER);
+        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith(BEARER_PREFIX)) {
+            return bearerToken.substring(BEARER_PREFIX.length());
+        }
+        return null;
+    }
+
+    // 토큰 검증
+    public boolean validateToken(String token) {
+        try {
+            Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token);
+            return true;
+        } catch (SecurityException | MalformedJwtException e) {
+            log.error("Invalid JWT signature, 유효하지 않는 JWT 서명 입니다.");
+        } catch (ExpiredJwtException e) {
+            log.error("Expired JWT token, 만료된 JWT token 입니다.");
+        } catch (UnsupportedJwtException e) {
+            log.error("Unsupported JWT token, 지원되지 않는 JWT 토큰 입니다.");
+        } catch (IllegalArgumentException e) {
+            log.error("JWT claims is empty, 잘못된 JWT 토큰 입니다.");
+        }
+        return false;
+    }
+
+    // 토큰에서 사용자 정보 가져오기
+    public Claims getUserInfoFromToken(String token) {
+        return Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token).getBody();
+    }
+}

--- a/src/main/java/com/teamJ/budgetManagementApplication/common/security/UserDetailsImpl.java
+++ b/src/main/java/com/teamJ/budgetManagementApplication/common/security/UserDetailsImpl.java
@@ -1,0 +1,65 @@
+package com.teamJ.budgetManagementApplication.common.security;
+
+import com.teamJ.budgetManagementApplication.user.entity.User;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+public class UserDetailsImpl implements UserDetails {
+    private final User user;
+
+    public UserDetailsImpl(User user) {
+        this.user = user;
+    }
+
+    public User getUser() {
+        return user;
+    }
+
+    public String getAccount() {
+        return user.getAccount();
+    }
+
+    @Override
+    public String getPassword() {
+        return user.getPassword();
+    }
+
+    @Override
+    public String getUsername() {
+        return null;
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        String authority = "ROLE_USER";
+        SimpleGrantedAuthority simpleGrantedAuthority = new SimpleGrantedAuthority(authority);
+        Collection<GrantedAuthority> authorities = new ArrayList<>();
+        authorities.add(simpleGrantedAuthority);
+
+        return authorities;
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+}

--- a/src/main/java/com/teamJ/budgetManagementApplication/common/security/UserDetailsServiceImpl.java
+++ b/src/main/java/com/teamJ/budgetManagementApplication/common/security/UserDetailsServiceImpl.java
@@ -1,0 +1,25 @@
+package com.teamJ.budgetManagementApplication.common.security;
+
+import com.teamJ.budgetManagementApplication.user.entity.User;
+import com.teamJ.budgetManagementApplication.user.reository.UserRepository;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@Service
+public class UserDetailsServiceImpl implements UserDetailsService {
+    private final UserRepository userRepository;
+
+    public UserDetailsServiceImpl(UserRepository userRepository) {
+        this.userRepository = userRepository;
+    }
+
+    @Override
+    public UserDetails loadUserByUsername(String account) throws UsernameNotFoundException {
+        User user = userRepository.findByAccount(account)
+                .orElseThrow(() -> new UsernameNotFoundException("Not found " + account));
+
+        return new UserDetailsImpl(user);
+    }
+}

--- a/src/main/java/com/teamJ/budgetManagementApplication/common/security/WebSecurityConfig.java
+++ b/src/main/java/com/teamJ/budgetManagementApplication/common/security/WebSecurityConfig.java
@@ -1,0 +1,67 @@
+package com.teamJ.budgetManagementApplication.common.security;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Configuration
+@RequiredArgsConstructor
+@EnableWebSecurity  // Spring Security 지원을 가능하게 함
+@EnableMethodSecurity(securedEnabled = true)
+public class WebSecurityConfig {
+    private final JwtUtil jwtUtil;
+    private final UserDetailsServiceImpl userDetailsService;
+    private final AuthenticationConfiguration authenticationConfiguration;
+
+    @Bean
+    public AuthenticationManager authenticationManager(AuthenticationConfiguration configuration) throws Exception {
+        return configuration.getAuthenticationManager();
+    }
+
+    @Bean
+    public JwtAuthenticationFilter jwtAuthenticationFilter() throws Exception {
+        JwtAuthenticationFilter filter = new JwtAuthenticationFilter(jwtUtil);
+        filter.setAuthenticationManager(authenticationManager(authenticationConfiguration));
+        return filter;
+    }
+
+    @Bean
+    public JwtAuthorizationFilter jwtAuthorizationFilter() {
+        return new JwtAuthorizationFilter(jwtUtil, userDetailsService);
+    }
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        // CSRF 설정
+        http.csrf(AbstractHttpConfigurer::disable);
+
+        // Session -> 사용하지 않음.
+        http.sessionManagement(sessionManagement ->
+                sessionManagement.sessionCreationPolicy(SessionCreationPolicy.STATELESS));
+
+        http.authorizeHttpRequests(authorizeHttpRequests ->
+                authorizeHttpRequests
+                        // '/api/users'로 시작하는 요청 중 모든 POST 접근 허가
+                        .requestMatchers(HttpMethod.POST, "/api/users/**").permitAll()
+                        // swagger-ui 와 관련된 모든 요청 접근 허가
+                        .requestMatchers("/swagger-ui/**", "/v3/**").permitAll()
+                        .anyRequest().authenticated() // 그 외 모든 요청 인증처리
+        );
+
+        // 필터 관리
+        http.addFilterBefore(jwtAuthorizationFilter(), JwtAuthenticationFilter.class);
+        http.addFilterBefore(jwtAuthenticationFilter(), UsernamePasswordAuthenticationFilter.class);
+
+        return http.build();
+    }
+}

--- a/src/main/java/com/teamJ/budgetManagementApplication/user/dto/LoginRequestDto.java
+++ b/src/main/java/com/teamJ/budgetManagementApplication/user/dto/LoginRequestDto.java
@@ -1,0 +1,9 @@
+package com.teamJ.budgetManagementApplication.user.dto;
+
+import lombok.Getter;
+
+@Getter
+public class LoginRequestDto {
+    private String account;
+    private String password;
+}


### PR DESCRIPTION
## 관련 Issue

* close #9

## 변경 사항

* JWT 의존성 추가
* JWT Util 구현
* JWT 필터 구현
* WebSecurityConfig 생성
* LoginRequestDto 생성
* 회원가입, 로그인 API만 pass하도록 설정

<br>

- [x] 포스트맨으로 체크해 보았나요?

|`account`가 틀렸을 때 - 로그인 실패|`password`가 틀렸을 때 - 로그인 실패|
|:---:|:---:|
|![image](https://github.com/JisooPyo/budget-management-application/assets/130378232/8ab527f1-ebac-4f85-a00f-6a41ebc01ca2)|![image](https://github.com/JisooPyo/budget-management-application/assets/130378232/2df86730-1e0b-4c90-9af5-46aa11610beb)|
|**로그인 성공**|**토큰 발급 확인**|
|![image](https://github.com/JisooPyo/budget-management-application/assets/130378232/fd4f9c4d-68cd-4049-a592-c98d7f89dfe8)|![image](https://github.com/JisooPyo/budget-management-application/assets/130378232/8240b82b-79f1-4533-8f24-983a9bc923e4)|

## 트러블 슈팅

### JWT secret Key 관련 예외

* **발생한 예외**

```java
Caused by: java.lang.IllegalArgumentException: Input byte array has incorrect ending byte at 40
```

<br>

* **예외가 발생한 코드**

```java
@PostConstruct
public void init() {
	byte[] bytes = Base64.getDecoder().decode(secretKey);
	key = Keys.hmacShaKeyFor(bytes);
}
```

<br>

* **원인 분석과 해결**

나는 `JWT Secret Key`가 아무 key를 넣으면 된다고 생각했는데 코드를 보니 `Base64`로 인코딩된 것을 다시 디코딩하여 이를 `JWT HMAC-SHA` 알고리즘으로 다시 인코딩한 값이 key로 들어가는 것이었다.
Web에서 `Base64` 인코더를 찾아 내가 넣고 싶은 key값을 인코딩해준 뒤, 다시 key에 넣어주었더니 해결되었다..! `Security`관련된 코드는 전체적으로 흐름만 보고 이해했었는데 조금 더 자세히 봐야 할 필요성을 느꼈다.