### PR TITLE
[feature] 카테고리 목록 API 구현

### DIFF
--- a/src/main/java/com/teamJ/budgetManagementApplication/category/controller/CategoryController.java
+++ b/src/main/java/com/teamJ/budgetManagementApplication/category/controller/CategoryController.java
@@ -1,0 +1,30 @@
+package com.teamJ.budgetManagementApplication.category.controller;
+
+import com.teamJ.budgetManagementApplication.category.dto.CategoryResponseDto;
+import com.teamJ.budgetManagementApplication.category.service.CategoryService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api")
+@Tag(name = "Category API", description = "Category에 대한 API 정보를 담고 있습니다.")
+public class CategoryController {
+    private final CategoryService categoryService;
+
+    @Operation(summary = "카테고리 목록 가져오기",
+            description = "모든 카테고리 목록을 반환합니다.")
+    @GetMapping("/categories")
+    public ResponseEntity<List<CategoryResponseDto>> getCategories() {
+        List<CategoryResponseDto> results = categoryService.getCategories();
+        return ResponseEntity.ok().body(results);
+    }
+
+}

--- a/src/main/java/com/teamJ/budgetManagementApplication/category/dto/CategoryResponseDto.java
+++ b/src/main/java/com/teamJ/budgetManagementApplication/category/dto/CategoryResponseDto.java
@@ -1,0 +1,15 @@
+package com.teamJ.budgetManagementApplication.category.dto;
+
+import com.teamJ.budgetManagementApplication.category.entity.Category;
+import lombok.Getter;
+
+@Getter
+public class CategoryResponseDto {
+    private Long id;
+    private String name;
+
+    public CategoryResponseDto(Category category) {
+        this.id = category.getId();
+        this.name = category.getName();
+    }
+}

--- a/src/main/java/com/teamJ/budgetManagementApplication/category/reposiroty/CategoryRepository.java
+++ b/src/main/java/com/teamJ/budgetManagementApplication/category/reposiroty/CategoryRepository.java
@@ -1,0 +1,13 @@
+package com.teamJ.budgetManagementApplication.category.reposiroty;
+
+import com.teamJ.budgetManagementApplication.category.entity.Category;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface CategoryRepository extends JpaRepository<Category, Long> {
+
+    List<Category> findAllByOrderByIdAsc();
+}

--- a/src/main/java/com/teamJ/budgetManagementApplication/category/service/CategoryService.java
+++ b/src/main/java/com/teamJ/budgetManagementApplication/category/service/CategoryService.java
@@ -1,0 +1,14 @@
+package com.teamJ.budgetManagementApplication.category.service;
+
+import com.teamJ.budgetManagementApplication.category.dto.CategoryResponseDto;
+
+import java.util.List;
+
+public interface CategoryService {
+    /**
+     * 모든 카테고리 목록을 반환합니다.
+     *
+     * @return 모든 카테고리 목록
+     */
+    List<CategoryResponseDto> getCategories();
+}

--- a/src/main/java/com/teamJ/budgetManagementApplication/category/service/CategoryServiceImpl.java
+++ b/src/main/java/com/teamJ/budgetManagementApplication/category/service/CategoryServiceImpl.java
@@ -1,0 +1,23 @@
+package com.teamJ.budgetManagementApplication.category.service;
+
+import com.teamJ.budgetManagementApplication.category.dto.CategoryResponseDto;
+import com.teamJ.budgetManagementApplication.category.entity.Category;
+import com.teamJ.budgetManagementApplication.category.reposiroty.CategoryRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class CategoryServiceImpl implements CategoryService {
+
+    private final CategoryRepository categoryRepository;
+
+    @Override
+    public List<CategoryResponseDto> getCategories() {
+        List<Category> categories = categoryRepository.findAllByOrderByIdAsc();
+
+        return categories.stream().map(CategoryResponseDto::new).toList();
+    }
+}


### PR DESCRIPTION
## 관련 Issue

* close #10

## 변경 사항

* 모든 카테고리 목록을 반환하는 기능 구현
  * 현재는 id순으로 정렬하여 내보내고 있습니다.
  * 후에 `지출에서 가장 많이 적은 순`으로 내보내 줄 수도 있겠습니다.

- [x] 포스트맨으로 체크해 보았나요?

* DB에 있는 category

![image](https://github.com/JisooPyo/budget-management-application/assets/130378232/f2a6f33e-3193-4c05-83b9-28c9797ab2a3)

* Postman으로 모든 category가 잘 불러와짐을 확인할 수 있다.

![image](https://github.com/JisooPyo/budget-management-application/assets/130378232/f8e8b84b-6646-4e0b-b28a-db8d0151c32f)