### PR TITLE
[hotfix] 다른 유저가 같은 기간 예산 설정 안되는 오류 수정

### DIFF
--- a/src/main/java/com/teamJ/budgetManagementApplication/budget/repository/BudgetRepository.java
+++ b/src/main/java/com/teamJ/budgetManagementApplication/budget/repository/BudgetRepository.java
@@ -1,6 +1,7 @@
 package com.teamJ.budgetManagementApplication.budget.repository;
 
 import com.teamJ.budgetManagementApplication.budget.entity.Budget;
+import com.teamJ.budgetManagementApplication.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -8,5 +9,5 @@ import java.util.Optional;
 
 @Repository
 public interface BudgetRepository extends JpaRepository<Budget, Long> {
-    Optional<Budget> findByYearAndMonth(Integer year, Integer month);
+    Optional<Budget> findByYearAndMonthAndUser(Integer year, Integer month, User user);
 }

--- a/src/main/java/com/teamJ/budgetManagementApplication/budget/service/BudgetServiceImpl.java
+++ b/src/main/java/com/teamJ/budgetManagementApplication/budget/service/BudgetServiceImpl.java
@@ -27,14 +27,14 @@ public class BudgetServiceImpl implements BudgetService {
 
         int year = budgetSetRequestDto.getYear();
         int month = budgetSetRequestDto.getMonth();
-        checkBudgetExists(year, month);
+        checkBudgetExists(year, month, targetUser);
 
         int totalBudget = getTotalBudget(budgetSetRequestDto);
         Budget budget = Budget.builder().user(targetUser)
                 .year(year).month(month).money(totalBudget).build();
         budgetRepository.save(budget);
 
-        Budget targetBudget = findTargetBudget(year, month);
+        Budget targetBudget = findTargetBudget(year, month, targetUser);
         budgetCategoryService.saveBudgetCategory(targetBudget, budgetSetRequestDto);
     }
 
@@ -44,7 +44,7 @@ public class BudgetServiceImpl implements BudgetService {
         Budget targetBudget = findBudget(id);
         checkAuthorizedUser(targetBudget, targetUser);
 
-        budgetCategoryService.updateBudget(targetBudget,requestDto);
+        budgetCategoryService.updateBudget(targetBudget, requestDto);
     }
 
     private int getTotalBudget(BudgetSetRequestDto budgetSetRequestDto) {
@@ -56,14 +56,14 @@ public class BudgetServiceImpl implements BudgetService {
                 + budgetSetRequestDto.getTransportation();
     }
 
-    private void checkBudgetExists(int year, int month) {
-        if (budgetRepository.findByYearAndMonth(year, month).isPresent()) {
+    private void checkBudgetExists(int year, int month, User targetUser) {
+        if (budgetRepository.findByYearAndMonthAndUser(year, month, targetUser).isPresent()) {
             throw new CustomException(CustomErrorCode.BUDGET_ALREADY_EXISTS);
         }
     }
 
-    private Budget findTargetBudget(int year, int month) {
-        return budgetRepository.findByYearAndMonth(year, month).orElseThrow(
+    private Budget findTargetBudget(int year, int month, User targetUser) {
+        return budgetRepository.findByYearAndMonthAndUser(year, month, targetUser).orElseThrow(
                 () -> new CustomException(CustomErrorCode.BUDGET_NOT_FOUND)
         );
     }


### PR DESCRIPTION
## 관련 Issue

* close #34 

## 변경 사항

* user1이 2023년 3월에 예산 설정시, user2가 2023년 3월에 예산 설정하지 못하는 에러 해결
* 원인 : `year`와 `month`만으로 식별하는 로직이 있었다. -> `year`, `month`, `user`로 식별하는 로직으로 변경
* `year`와 `month`가 `database`상에서 UK로 묶여져 있어서 index 삭제 진행

- [x] 포스트맨으로 체크해 보았나요?

DB 확인

![image](https://github.com/JisooPyo/budget-management-application/assets/130378232/128a3622-1347-41f7-b2c2-360c7f328aa9)