### PR TITLE
[feature] 지출 생성 API

### DIFF
--- a/src/main/java/com/teamJ/budgetManagementApplication/budget/controller/BudgetController.java
+++ b/src/main/java/com/teamJ/budgetManagementApplication/budget/controller/BudgetController.java
@@ -21,7 +21,7 @@ import java.util.List;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/budgets")
-@Tag(name = "Budget API", description = "예상 설정 API 정보를 담고 있습니다.")
+@Tag(name = "Budget API", description = "예산에 관한 API 정보를 담고 있습니다.")
 public class BudgetController {
     private final BudgetService budgetService;
 

--- a/src/main/java/com/teamJ/budgetManagementApplication/category/service/CategoryServiceImpl.java
+++ b/src/main/java/com/teamJ/budgetManagementApplication/category/service/CategoryServiceImpl.java
@@ -58,4 +58,10 @@ public class CategoryServiceImpl implements CategoryService {
                 () -> new CustomException(CustomErrorCode.CATEGORY_NOT_FOUND)
         );
     }
+
+    public Category findCategory(Long id) {
+        return categoryRepository.findById(id).orElseThrow(
+                () -> new CustomException(CustomErrorCode.CATEGORY_NOT_FOUND)
+        );
+    }
 }

--- a/src/main/java/com/teamJ/budgetManagementApplication/common/exception/CustomErrorCode.java
+++ b/src/main/java/com/teamJ/budgetManagementApplication/common/exception/CustomErrorCode.java
@@ -14,7 +14,8 @@ public enum CustomErrorCode {
     BUDGET_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "예산이 존재하지 않습니다."),
     CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "카테고리가 존재하지 않습니다."),
     ACCESS_DENIED(HttpStatus.BAD_REQUEST.value(), "잘못된 접근입니다."),
-    BUDGET_CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "예산-카테고리가 존재하지 않습니다.");
+    BUDGET_CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "예산-카테고리가 존재하지 않습니다."),
+    EXPENSE_ALREADY_EXISTS(HttpStatus.BAD_REQUEST.value(), "이미 존재하는 지출입니다.");
 
     private final int errorCode;
     private final String errorMessage;

--- a/src/main/java/com/teamJ/budgetManagementApplication/expense/controller/ExpenseController.java
+++ b/src/main/java/com/teamJ/budgetManagementApplication/expense/controller/ExpenseController.java
@@ -1,0 +1,36 @@
+package com.teamJ.budgetManagementApplication.expense.controller;
+
+import com.teamJ.budgetManagementApplication.common.dto.ApiResponseDto;
+import com.teamJ.budgetManagementApplication.common.security.UserDetailsImpl;
+import com.teamJ.budgetManagementApplication.expense.dto.ExpenseCreateRequestDto;
+import com.teamJ.budgetManagementApplication.expense.service.ExpenseService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api")
+@Tag(name = "지출 API", description = "지출에 관한 API 정보를 담고 있습니다.")
+public class ExpenseController {
+    private final ExpenseService expenseService;
+
+    @Operation(summary = "지출 생성", description = "사용자에게 필요한 정보를 받아 지출을 기록합니다.")
+    @PostMapping("/expenses")
+    public ResponseEntity<ApiResponseDto> createExpense(
+            @Valid @RequestBody ExpenseCreateRequestDto requestDto,
+            @AuthenticationPrincipal UserDetailsImpl userDetails) {
+        expenseService.createExpense(requestDto, userDetails.getUser());
+        return ResponseEntity.ok().body(
+                new ApiResponseDto(HttpStatus.CREATED.value(), "지출 기록 완료")
+        );
+    }
+}

--- a/src/main/java/com/teamJ/budgetManagementApplication/expense/dto/ExpenseCreateRequestDto.java
+++ b/src/main/java/com/teamJ/budgetManagementApplication/expense/dto/ExpenseCreateRequestDto.java
@@ -1,8 +1,6 @@
 package com.teamJ.budgetManagementApplication.expense.dto;
 
 import jakarta.validation.constraints.Min;
-import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 import lombok.Builder;
 import lombok.Getter;

--- a/src/main/java/com/teamJ/budgetManagementApplication/expense/dto/ExpenseCreateRequestDto.java
+++ b/src/main/java/com/teamJ/budgetManagementApplication/expense/dto/ExpenseCreateRequestDto.java
@@ -1,0 +1,24 @@
+package com.teamJ.budgetManagementApplication.expense.dto;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+@Getter
+@Builder
+public class ExpenseCreateRequestDto {
+    @Min(value = 1, message = "카테고리 ID는 1 이상이어야 합니다.")
+    private long categoryId;
+    @NotNull
+    private LocalDate date;
+    @Min(value = 1, message = "기록하는 지출금액은 0보다 커야 합니다.")
+    private int money;
+    @NotNull
+    private String memo;
+    private boolean excludeFromSum;
+}

--- a/src/main/java/com/teamJ/budgetManagementApplication/expense/entity/Expense.java
+++ b/src/main/java/com/teamJ/budgetManagementApplication/expense/entity/Expense.java
@@ -3,12 +3,18 @@ package com.teamJ.budgetManagementApplication.expense.entity;
 import com.teamJ.budgetManagementApplication.category.entity.Category;
 import com.teamJ.budgetManagementApplication.user.entity.User;
 import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.time.LocalDate;
 
 @Entity
 @Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class Expense {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/teamJ/budgetManagementApplication/expense/repository/ExpenseRepository.java
+++ b/src/main/java/com/teamJ/budgetManagementApplication/expense/repository/ExpenseRepository.java
@@ -1,0 +1,13 @@
+package com.teamJ.budgetManagementApplication.expense.repository;
+
+import com.teamJ.budgetManagementApplication.expense.entity.Expense;
+import com.teamJ.budgetManagementApplication.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface ExpenseRepository extends JpaRepository<Expense, Long> {
+    Optional<Expense> findByUser(User user);
+}

--- a/src/main/java/com/teamJ/budgetManagementApplication/expense/service/ExpenseService.java
+++ b/src/main/java/com/teamJ/budgetManagementApplication/expense/service/ExpenseService.java
@@ -1,0 +1,14 @@
+package com.teamJ.budgetManagementApplication.expense.service;
+
+import com.teamJ.budgetManagementApplication.expense.dto.ExpenseCreateRequestDto;
+import com.teamJ.budgetManagementApplication.user.entity.User;
+
+public interface ExpenseService {
+    /**
+     * 지출 생성
+     *
+     * @param requestDto 지출 기록에 필요한 요청 정보
+     * @param user       인증된 유저 정보
+     */
+    void createExpense(ExpenseCreateRequestDto requestDto, User user);
+}

--- a/src/main/java/com/teamJ/budgetManagementApplication/expense/service/ExpenseServiceImpl.java
+++ b/src/main/java/com/teamJ/budgetManagementApplication/expense/service/ExpenseServiceImpl.java
@@ -1,0 +1,43 @@
+package com.teamJ.budgetManagementApplication.expense.service;
+
+import com.teamJ.budgetManagementApplication.category.entity.Category;
+import com.teamJ.budgetManagementApplication.category.service.CategoryServiceImpl;
+import com.teamJ.budgetManagementApplication.common.exception.CustomErrorCode;
+import com.teamJ.budgetManagementApplication.common.exception.CustomException;
+import com.teamJ.budgetManagementApplication.expense.dto.ExpenseCreateRequestDto;
+import com.teamJ.budgetManagementApplication.expense.entity.Expense;
+import com.teamJ.budgetManagementApplication.expense.repository.ExpenseRepository;
+import com.teamJ.budgetManagementApplication.user.entity.User;
+import com.teamJ.budgetManagementApplication.user.service.UserServiceImpl;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class ExpenseServiceImpl implements ExpenseService {
+    private final ExpenseRepository expenseRepository;
+    private final UserServiceImpl userService;
+    private final CategoryServiceImpl categoryService;
+
+    @Override
+    public void createExpense(ExpenseCreateRequestDto requestDto, User user) {
+        User targetUser = userService.findUser(user.getAccount());
+        checkExpense(targetUser);
+        Category category = categoryService.findCategory(requestDto.getCategoryId());
+        Expense expense = Expense.builder().user(targetUser).category(category)
+                .date(requestDto.getDate())
+                .money(requestDto.getMoney())
+                .memo(requestDto.getMemo())
+                .excludeFromSum(requestDto.isExcludeFromSum())
+                .build();
+        expenseRepository.save(expense);
+    }
+
+    private void checkExpense(User targetUser) {
+        if (expenseRepository.findByUser(targetUser).isPresent()) {
+            throw new CustomException(CustomErrorCode.EXPENSE_ALREADY_EXISTS);
+        }
+    }
+}


### PR DESCRIPTION
## 관련 Issue

* close #18 

## 변경 사항

* BudgetController Swagger Tag 수정 -> 오타 수정
* 지출 생성 API 구현 완료

- [X] 포스트맨으로 체크해 보았나요?

|카테고리가 존재하지 않을 때|지출 생성 완료|
|:---:|:---:|
|![image](https://github.com/JisooPyo/budget-management-application/assets/130378232/a1b9904d-1dee-446a-bee8-7b1506be36e1)|![image](https://github.com/JisooPyo/budget-management-application/assets/130378232/6c952bc3-c9f6-4159-b7d8-4e5750875340)|

## 트러블 슈팅

### validation 문제

`@NotNull`, `@NotEmpty`, `@NotBlank`의 차이에 대해서 숙지하지 못해 있었던 문제

* `@NotNull` : null 허용 x
* `@NotEmpty` : null, "" 혀용 x
* `@NotBlank` : null, "", " " 허용 x

-> long, boolean 타입의 경우 null을 허용하지 않는 타입이므로 애초에 validation이 필요 없다.
-> LocalDate의 경우 `@NotEmpty`를 쓸 수 없다.