### PR TITLE
[feature] 지출 수정 API

### DIFF
--- a/src/main/java/com/teamJ/budgetManagementApplication/common/exception/GlobalControllerAdvice.java
+++ b/src/main/java/com/teamJ/budgetManagementApplication/common/exception/GlobalControllerAdvice.java
@@ -4,6 +4,7 @@ import com.teamJ.budgetManagementApplication.common.dto.ApiResponseDto;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.MissingServletRequestParameterException;
@@ -55,5 +56,15 @@ public class GlobalControllerAdvice {
         return ResponseEntity.badRequest().body(
                 new ApiResponseDto(HttpStatus.BAD_REQUEST.value(),
                         e.getName() + "가 알맞은 값이 아닙니다."));
+    }
+
+    // RequestBody를 제대로 읽지 못했을 때
+    // ex. RequestBody에 LocalDate 변수가 있는데 이를 타입에 맞게끔 보내주지 않았을 때("date":2023)
+    @ExceptionHandler({HttpMessageNotReadableException.class})
+    public ResponseEntity<ApiResponseDto> handlerMessageNotReadableException(
+            HttpMessageNotReadableException e) {
+        return ResponseEntity.badRequest().body(
+                new ApiResponseDto(HttpStatus.BAD_REQUEST.value(),
+                        "요청정보가 잘못되었습니다."));
     }
 }

--- a/src/main/java/com/teamJ/budgetManagementApplication/expense/controller/ExpenseController.java
+++ b/src/main/java/com/teamJ/budgetManagementApplication/expense/controller/ExpenseController.java
@@ -5,6 +5,7 @@ import com.teamJ.budgetManagementApplication.common.security.UserDetailsImpl;
 import com.teamJ.budgetManagementApplication.expense.dto.ExpenseCreateRequestDto;
 import com.teamJ.budgetManagementApplication.expense.dto.ExpenseListResponseDto;
 import com.teamJ.budgetManagementApplication.expense.dto.ExpenseResponseDto;
+import com.teamJ.budgetManagementApplication.expense.dto.ExpenseUpdateRequestDto;
 import com.teamJ.budgetManagementApplication.expense.service.ExpenseService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -57,4 +58,17 @@ public class ExpenseController {
                 expenseService.getExpense(id, userDetails.getUser())
         );
     }
+
+    @Operation(summary = "지출 수정", description = "수정에 필요한 정보를 받아 지출을 수정합니다.")
+    @PutMapping("/expenses/{id}")
+    public ResponseEntity<ApiResponseDto> updateExpense(
+            @PathVariable Long id,
+            @Valid @RequestBody ExpenseUpdateRequestDto requestDto,
+            @AuthenticationPrincipal UserDetailsImpl userDetails) {
+        expenseService.updateExpense(id, requestDto, userDetails.getUser());
+        return ResponseEntity.ok().body(
+                new ApiResponseDto(HttpStatus.OK.value(), "지출 수정 완료")
+        );
+    }
+
 }

--- a/src/main/java/com/teamJ/budgetManagementApplication/expense/dto/ExpenseUpdateRequestDto.java
+++ b/src/main/java/com/teamJ/budgetManagementApplication/expense/dto/ExpenseUpdateRequestDto.java
@@ -1,0 +1,19 @@
+package com.teamJ.budgetManagementApplication.expense.dto;
+
+import jakarta.validation.constraints.Min;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+@Getter
+@Builder
+public class ExpenseUpdateRequestDto {
+    @Min(value = 1, message = "카테고리 ID는 1 이상이어야 합니다.")
+    private Long categoryId;
+    private LocalDate date;
+    @Min(value = 1, message = "기록하는 지출금액은 0보다 커야 합니다.")
+    private Integer money;
+    private String memo;
+    private Boolean excludeFromSum;
+}

--- a/src/main/java/com/teamJ/budgetManagementApplication/expense/entity/Expense.java
+++ b/src/main/java/com/teamJ/budgetManagementApplication/expense/entity/Expense.java
@@ -1,13 +1,16 @@
 package com.teamJ.budgetManagementApplication.expense.entity;
 
 import com.teamJ.budgetManagementApplication.category.entity.Category;
+import com.teamJ.budgetManagementApplication.expense.dto.ExpenseCreateRequestDto;
 import com.teamJ.budgetManagementApplication.expense.dto.ExpenseResponseDto;
+import com.teamJ.budgetManagementApplication.expense.dto.ExpenseUpdateRequestDto;
 import com.teamJ.budgetManagementApplication.user.entity.User;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.DynamicUpdate;
 
 import java.time.LocalDate;
 
@@ -16,6 +19,7 @@ import java.time.LocalDate;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
+@DynamicUpdate
 public class Expense {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -49,5 +53,23 @@ public class Expense {
                 .money(money)
                 .memo(memo)
                 .build();
+    }
+
+    public void update(Category category, ExpenseUpdateRequestDto requestDto) {
+        if(category!=null){
+            this.category = category;
+        }
+        if(requestDto.getDate()!=null){
+            this.date = requestDto.getDate();
+        }
+        if(requestDto.getMoney()!=null){
+            this.money = requestDto.getMoney();
+        }
+        if(requestDto.getMemo()!=null){
+            this.memo = requestDto.getMemo();
+        }
+        if(requestDto.getExcludeFromSum()!=null){
+            this.excludeFromSum = requestDto.getExcludeFromSum();
+        }
     }
 }

--- a/src/main/java/com/teamJ/budgetManagementApplication/expense/service/ExpenseService.java
+++ b/src/main/java/com/teamJ/budgetManagementApplication/expense/service/ExpenseService.java
@@ -3,6 +3,7 @@ package com.teamJ.budgetManagementApplication.expense.service;
 import com.teamJ.budgetManagementApplication.expense.dto.ExpenseCreateRequestDto;
 import com.teamJ.budgetManagementApplication.expense.dto.ExpenseListResponseDto;
 import com.teamJ.budgetManagementApplication.expense.dto.ExpenseResponseDto;
+import com.teamJ.budgetManagementApplication.expense.dto.ExpenseUpdateRequestDto;
 import com.teamJ.budgetManagementApplication.user.entity.User;
 
 public interface ExpenseService {
@@ -35,4 +36,13 @@ public interface ExpenseService {
      * @return 조회된 지출의 정보
      */
     ExpenseResponseDto getExpense(Long id, User user);
+
+    /**
+     * 지출 수정
+     *
+     * @param id         지출 식별자
+     * @param requestDto 지출 수정에 필요한 정보
+     * @param user       인증된 유저 정보
+     */
+    void updateExpense(Long id, ExpenseUpdateRequestDto requestDto, User user);
 }

--- a/src/main/java/com/teamJ/budgetManagementApplication/expense/service/ExpenseServiceImpl.java
+++ b/src/main/java/com/teamJ/budgetManagementApplication/expense/service/ExpenseServiceImpl.java
@@ -4,10 +4,7 @@ import com.teamJ.budgetManagementApplication.category.entity.Category;
 import com.teamJ.budgetManagementApplication.category.service.CategoryServiceImpl;
 import com.teamJ.budgetManagementApplication.common.exception.CustomErrorCode;
 import com.teamJ.budgetManagementApplication.common.exception.CustomException;
-import com.teamJ.budgetManagementApplication.expense.dto.CategorySumResponseDto;
-import com.teamJ.budgetManagementApplication.expense.dto.ExpenseCreateRequestDto;
-import com.teamJ.budgetManagementApplication.expense.dto.ExpenseListResponseDto;
-import com.teamJ.budgetManagementApplication.expense.dto.ExpenseResponseDto;
+import com.teamJ.budgetManagementApplication.expense.dto.*;
 import com.teamJ.budgetManagementApplication.expense.entity.Expense;
 import com.teamJ.budgetManagementApplication.expense.repository.ExpenseRepository;
 import com.teamJ.budgetManagementApplication.user.entity.User;
@@ -65,6 +62,19 @@ public class ExpenseServiceImpl implements ExpenseService {
         Expense expense = findExpense(id);
         checkExpenseUser(expense, user);
         return expense.toExpenseResponseDto();
+    }
+
+    @Override
+    public void updateExpense(Long id, ExpenseUpdateRequestDto requestDto, User user) {
+        userService.findUser(user.getAccount());
+        Expense expense = findExpense(id);
+        checkExpenseUser(expense, user);
+        // 카테고리 수정 시
+        Category category = null;
+        if (requestDto.getCategoryId() != null) {
+            category = categoryService.findCategory(requestDto.getCategoryId());
+        }
+        expense.update(category, requestDto);
     }
 
     private void checkExpenseUser(Expense expense, User user) {


### PR DESCRIPTION
## 관련 Issue

* close #21 

## 변경 사항

* RequestDto에서 타입 잘못 입력할 시 예외 처리 - GlobalControllerAdvice
  * ex. LocalDate 타입을 "2023"으로 넘겼을 시
* 지출 수정 API 구현

- [X] 포스트맨으로 체크해 보았나요?

* 예외 처리
  * 수정하려는 카테고리가 존재하지 않을 때
  * 수정하려는 날짜 입력이 잘못될 경우
  * 다른 사람의 지출을 수정할 경우
 
|수정하려는 카테고리가 존재하지 않을 때|수정하려는 날짜 입력이 잘못될 경우|
|:---:|:---:|
|![image](https://github.com/JisooPyo/budget-management-application/assets/130378232/4ea9c494-b233-403c-bc96-4074ac01569d)|![image](https://github.com/JisooPyo/budget-management-application/assets/130378232/131f87ae-ff39-4926-9ab5-ae4a43a4c217)|
|**다른 사람의 지출을 수정할 경우**||
|![image](https://github.com/JisooPyo/budget-management-application/assets/130378232/69385f5c-bf3c-4fd3-8ae6-49d210e6dca4)||

* 지출 수정 테스트

![image](https://github.com/JisooPyo/budget-management-application/assets/130378232/0eb13f96-5c24-4498-8869-b31e9c64b943)

![image](https://github.com/JisooPyo/budget-management-application/assets/130378232/cd9df298-d068-4519-b430-aa4a3f7af2c8)
