### PR TITLE
[feature] 지출 삭제 API

### DIFF
--- a/src/main/java/com/teamJ/budgetManagementApplication/expense/controller/ExpenseController.java
+++ b/src/main/java/com/teamJ/budgetManagementApplication/expense/controller/ExpenseController.java
@@ -71,4 +71,14 @@ public class ExpenseController {
         );
     }
 
+    @Operation(summary = "지출 삭제", description = "삭제에 필요한 지출 식별자를 받아 지출을 삭제합니다.")
+    @DeleteMapping("/expenses/{id}")
+    public ResponseEntity<ApiResponseDto> deleteExpense(
+            @PathVariable Long id,
+            @AuthenticationPrincipal UserDetailsImpl userDetails) {
+        expenseService.deleteExpense(id, userDetails.getUser());
+        return ResponseEntity.ok().body(
+                new ApiResponseDto(HttpStatus.OK.value(), "지출 삭제 완료")
+        );
+    }
 }

--- a/src/main/java/com/teamJ/budgetManagementApplication/expense/service/ExpenseService.java
+++ b/src/main/java/com/teamJ/budgetManagementApplication/expense/service/ExpenseService.java
@@ -45,4 +45,12 @@ public interface ExpenseService {
      * @param user       인증된 유저 정보
      */
     void updateExpense(Long id, ExpenseUpdateRequestDto requestDto, User user);
+
+    /**
+     * 지출 삭제
+     *
+     * @param id   지출 식별자
+     * @param user 인증된 유저 정보
+     */
+    void deleteExpense(Long id, User user);
 }

--- a/src/main/java/com/teamJ/budgetManagementApplication/expense/service/ExpenseServiceImpl.java
+++ b/src/main/java/com/teamJ/budgetManagementApplication/expense/service/ExpenseServiceImpl.java
@@ -77,6 +77,15 @@ public class ExpenseServiceImpl implements ExpenseService {
         expense.update(category, requestDto);
     }
 
+    @Override
+    public void deleteExpense(Long id, User user) {
+        userService.findUser(user.getAccount());
+        Expense expense = findExpense(id);
+        checkExpenseUser(expense, user);
+
+        expenseRepository.deleteById(id);
+    }
+
     private void checkExpenseUser(Expense expense, User user) {
         if (!expense.getUser().getId().equals(user.getId())) {
             throw new CustomException(CustomErrorCode.NOT_AUTHORIZED);


### PR DESCRIPTION
## 관련 Issue

* close #22 

## 변경 사항

* 지출 삭제 API 구현

- [X] 포스트맨으로 체크해 보았나요?

* 예외 처리
  * 다른 사람의 지출 삭제

|다른 사람의 지출 삭제|지출 삭제 성공|
|:---:|:---:|
|![image](https://github.com/JisooPyo/budget-management-application/assets/130378232/49713fd8-9f93-449e-bf56-6925a2ae7056)|![image](https://github.com/JisooPyo/budget-management-application/assets/130378232/2ed495a6-6a28-46c2-8458-b7fe142bec05)|

DB상에서 id 3번 지출 삭제 확인

![image](https://github.com/JisooPyo/budget-management-application/assets/130378232/327b5673-e5d7-4f09-8e1c-e0f2fd4a42b1)
